### PR TITLE
Global test config

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,11 +59,12 @@
     "gen:types": "apollo-codegen introspect-schema http://localhost:4000 && gql2ts --ignore-type-name-declaration schema.json -o src/types/schema.d.ts",
     "start": "ts-node src/index.ts",
     "start:dev": "nodemon --exec ts-node src/index.ts",
-    "test": "NODE_ENV=test jest --forceExit",
+    "test": "NODE_ENV=test jest",
     "test:watch": "NODE_ENV=test jest --watch"
   },
   "jest": {
-    "globalSetup": "./src/test/init.js",
+    "globalSetup": "./src/test/setup.js",
+    "globalTeardown": "./src/test/teardown.js",
     "testEnvironment": "node",
     "transform": {
       "^.+\\.tsx?$": "ts-jest"

--- a/src/modules/forgotPassword/forgotPassword.test.ts
+++ b/src/modules/forgotPassword/forgotPassword.test.ts
@@ -7,7 +7,7 @@ import { createTestConn } from '../../test/createTestConn';
 import { TestClient } from '../../test/TestClient';
 import { createForgotPasswordLink } from '../../util/createForgotPasswordLink';
 
-faker.seed(Date.now() + Math.random());
+
 
 describe('Forgot password', () => {
   const oldPassword = faker.internet.password();

--- a/src/modules/login/login.test.ts
+++ b/src/modules/login/login.test.ts
@@ -5,8 +5,6 @@ import { User } from '../../entity/User';
 import { createTestConn } from '../../test/createTestConn';
 import { TestClient } from '../../test/TestClient';
 
-faker.seed(Date.now() + Math.random());
-
 describe('Login', () => {
   let conn: Connection;
 

--- a/src/modules/logout/logout.test.ts
+++ b/src/modules/logout/logout.test.ts
@@ -5,8 +5,6 @@ import { User } from '../../entity/User';
 import { createTestConn } from '../../test/createTestConn';
 import { TestClient } from '../../test/TestClient';
 
-faker.seed(Date.now() + Math.random());
-
 describe('logout', () => {
   const password = faker.internet.password();
   let email: string;

--- a/src/modules/me/me.test.ts
+++ b/src/modules/me/me.test.ts
@@ -5,8 +5,6 @@ import { User } from '../../entity/User';
 import { createTestConn } from '../../test/createTestConn';
 import { TestClient } from '../../test/TestClient';
 
-faker.seed(Date.now() + Math.random());
-
 describe('me', () => {
   let conn: Connection;
   let email: string;

--- a/src/modules/register/register.test.ts
+++ b/src/modules/register/register.test.ts
@@ -5,8 +5,6 @@ import { User } from '../../entity/User';
 import { createTestConn } from '../../test/createTestConn';
 import { TestClient } from '../../test/TestClient';
 
-faker.seed(Date.now() + Math.random());
-
 describe('Register', () => {
   const password = faker.internet.password(10);
 

--- a/src/routes/tests/confirmEmail.test.ts
+++ b/src/routes/tests/confirmEmail.test.ts
@@ -8,7 +8,6 @@ import { createTestConn } from '../../test/createTestConn';
 import { createConfirmEmailLink } from '../../util/createConfirmEmailLink';
 
 const host = process.env.TEST_HOST as string;
-faker.seed(Date.now() + Math.random());
 
 describe('/confirm/:id', () => {
   let userId: string;

--- a/src/test/global.ts
+++ b/src/test/global.ts
@@ -1,0 +1,25 @@
+import { Server } from 'http';
+import { Redis } from 'ioredis';
+import { Connection } from 'typeorm';
+
+import { startServer } from '../server';
+
+let conn: Connection;
+let redis: Redis;
+let server: Server;
+
+export const setup = async () => {
+  const res = await startServer();
+
+  process.env.TEST_HOST = `http://127.0.0.1:${res.port}`;
+
+  conn = res.connection;
+  redis = res.redis;
+  server = res.server;
+
+  await redis.flushall();
+};
+
+export const teardown = async () => {
+  Promise.all([conn.close(), redis.quit(), server.close()]);
+};

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,6 +1,6 @@
 require('ts-node/register');
 
-const { setup } = require('./setup');
+const { setup } = require('./global');
 
 module.exports = async function() {
   if (!process.env.TEST_HOST) {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,7 +1,0 @@
-import { startServer } from '../server';
-
-export const setup = async () => {
-  const { port } = await startServer();
-
-  process.env.TEST_HOST = `http://127.0.0.1:${port}`;
-};

--- a/src/test/teardown.js
+++ b/src/test/teardown.js
@@ -1,0 +1,9 @@
+require('ts-node/register');
+
+const { teardown } = require('./global');
+
+module.exports = async function() {
+  await teardown();
+
+  return;
+};

--- a/src/util/lockAccount.ts
+++ b/src/util/lockAccount.ts
@@ -1,4 +1,5 @@
-import { Redis } from '../../node_modules/@types/ioredis';
+import { Redis } from 'ioredis';
+
 import { User } from '../entity/User';
 import { Session } from '../types';
 import { deleteAllSessionsByUserId } from './deleteAllSessionsByUserId';


### PR DESCRIPTION
### Main

- Add `globalTeardown` which closes all active connections
- Remove `faker.seed()`
- Move `redis.flushall()` out of server into global test setup
- Rename `init.ts` -> `global.ts`